### PR TITLE
Prevent access to uninitialized data object in new_handler() function

### DIFF
--- a/jquery.ba-resize.js
+++ b/jquery.ba-resize.js
@@ -190,7 +190,12 @@
       
       function new_handler( e, w, h ) {
         var elem = $(this),
-          data = $.data( this, str_data );
+          data = $.data( this, str_data );    
+                
+        // fix related to https://github.com/cowboy/jquery-resize/issues/1
+        if (data == null) { 
+          data = $.data( this, str_data, { w: null, h: null });
+        }
         
         // If called from the polling loop, w and h will be passed in as
         // arguments. If called manually, via .trigger( 'resize' ) or .resize(),

--- a/jquery.ba-resize.js
+++ b/jquery.ba-resize.js
@@ -193,8 +193,8 @@
           data = $.data( this, str_data );    
                 
         // fix related to https://github.com/cowboy/jquery-resize/issues/1
-        if (data == null) { 
-          data = $.data( this, str_data, { w: null, h: null });
+        if (data == null) {
+            data = { w: null, h: null };
         }
         
         // If called from the polling loop, w and h will be passed in as


### PR DESCRIPTION
fix related to https://github.com/cowboy/jquery-resize/issues/1
